### PR TITLE
Shellify check script

### DIFF
--- a/check
+++ b/check
@@ -1,53 +1,56 @@
 #!/bin/bash
-set -e
 
 offer_run() {
-    read -p "For more output, run $1. Run it now (Y/n)? " run
+    local run
 
-    case ${run:0:1} in
-        n|N )
-            exit 1
+    read -r -p "For more output, run ${*}. Run it now (Y/n)? " run
+
+    case "${run:0:1}" in
+        n|N)
+            exit 2
         ;;
-        * )
-            $1
+        *)
+            eval "${@}"
         ;;
     esac
 
     exit 1
 }
 
-if (php-cs-fixer fix --dry-run --config=.php-cs-fixer.php > /dev/null 2>/dev/null); then
+set -e
+
+if (php-cs-fixer fix --dry-run --config=.php-cs-fixer.php >/dev/null 2>&1); then
     echo '✅ php-cs-fixer OK'
 else
-    read -p "⚠️ php-cs-fixer found issues. Fix (Y/n)? " fix
-    case ${fix:0:1} in
-        n|N )
+    read -r -p "⚠️ php-cs-fixer found issues. Fix (Y/n)? " fix
+    case "${fix:0:1}" in
+        n|N)
             echo '❌ php-cs-fixer FAIL'
-            offer_run 'php-cs-fixer fix --config=.php-cs-fixer.php'
+            offer_run php-cs-fixer fix --config=.php-cs-fixer.php
         ;;
-        * )
-            if (php-cs-fixer fix --config=.php-cs-fixer.php > /dev/null 2>/dev/null); then
+        *)
+            if (php-cs-fixer fix --config=.php-cs-fixer.php >/dev/null 2>&1); then
                 echo '✅ php-cs-fixer OK'
             else
                 echo '❌ php-cs-fixer FAIL'
-                offer_run 'php-cs-fixer fix --config=.php-cs-fixer.php'
+                offer_run php-cs-fixer fix --config=.php-cs-fixer.php
             fi
         ;;
     esac
 fi
 
-if (./vendor/bin/phpstan analyse > /dev/null 2>/dev/null); then
+if (./vendor/bin/phpstan analyse >/dev/null 2>&1); then
     echo '✅ PHPStan OK'
 else
     echo '❌ PHPStan FAIL'
-    offer_run './vendor/bin/phpstan analyse'
+    offer_run ./vendor/bin/phpstan analyse
 fi
 
-if (./vendor/bin/pest > /dev/null 2>/dev/null); then
+if (./vendor/bin/pest >/dev/null 2>&1); then
     echo '✅ PEST OK'
 else
     echo '❌ PEST FAIL'
-    offer_run './vendor/bin/pest'
+    offer_run ./vendor/bin/pest
 fi
 
 echo '=================='


### PR DESCRIPTION
- `> /dev/null 2>/dev/null` is really `>/dev/null 2>&1`
- `offer_run` now accepts unlimited arguments
- case branches lost [their spaces](https://tldp.org/LDP/Bash-Beginners-Guide/html/sect_07_03.html)