### PR TITLE
Add twitter:creator meta tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ title(string $title)
 description(string $description)
 image(string $url)
 
+twitterCreator(string $username)
 twitterSite(string $username)
 twitterTitle(string $title)
 twitterDescription(string $description)

--- a/assets/views/components/extensions/twitter.blade.php
+++ b/assets/views/components/extensions/twitter.blade.php
@@ -1,4 +1,5 @@
 <meta name="twitter:card" content="summary_large_image">
+@if(seo('twitter.creator')) <meta name="twitter:creator" content="@seo('twitter.creator')"> @endif
 @if(seo('twitter.site')) <meta name="twitter:site" content="@seo('twitter.site')"> @endif
 @if(seo('twitter.title')) <meta name="twitter:title" content="@seo('twitter.title')"> @endif
 @if(seo('twitter.description')) <meta name="twitter:description" content="@seo('twitter.description')"> @endif

--- a/src/SEOManager.php
+++ b/src/SEOManager.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Str;
  * @method $this image(string $url = null, ...$args) Set the cover image.
  * @method $this type(string $type = null, ...$args) Set the page type.
  * @method $this twitter(enabled $bool = true, ...$args) Enable the Twitter extension.
+ * @method $this twitterCreator(string $username = null, ...$args) Set the Twitter author.
  * @method $this twitterSite(string $username = null, ...$args) Set the Twitter author.
  * @method $this twitterTitle(string $title = null, ...$args) Set the Twitter title.
  * @method $this twitterDescription(string $description = null, ...$args) Set the Twitter description.
@@ -55,7 +56,7 @@ class SEOManager
     {
         return collect([
                 'site', 'title', 'image', 'description', 'url', 'type',
-                'twitter.site', 'twitter.title', 'twitter.image', 'twitter.description',
+                'twitter.creator', 'twitter.site', 'twitter.title', 'twitter.image', 'twitter.description',
             ])
             ->merge(array_keys($this->defaults))
             ->merge(array_keys($this->values))

--- a/tests/Pest/ExtensionTest.php
+++ b/tests/Pest/ExtensionTest.php
@@ -25,7 +25,7 @@ test('the twitter extension can be disabled by calling twitter with false', func
 test('when an extension is enabled, all of its keys are included in the resolved values', function () {
     expect(seo()->twitter()->all())
         ->not()->toBeEmpty()
-        ->toHaveKeys(['twitter.title', 'twitter.description', 'twitter.site', 'twitter.image']);
+        ->toHaveKeys(['twitter.title', 'twitter.description', 'twitter.creator', 'twitter.site', 'twitter.image']);
 });
 
 test('extension keys can be set by prefixing the call with the extension name and using camelcase', function () {


### PR DESCRIPTION
Additionally to the `twitter:site` meta tag, this Pull Request adds the `creator` one to indicate who is responsible for the article instead of the whole site.