### PR TITLE
Previewify needs prefix to work correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ seo()->previewify('page', 83);
 
 After that, you can use the templates by calling `seo()->previewify()` like this:
 ```php
-seo()->previewify('blog', ['title' => 'Foo', 'content' => 'bar'])`
+seo()->previewify('blog', ['previewify:title' => 'Foo', 'previewify:content' => 'bar'])`
 ```
 
 The call will set the generated image as the OpenGraph and Twitter card images. The generated URLs are signed.

--- a/src/SEOManager.php
+++ b/src/SEOManager.php
@@ -192,8 +192,8 @@ class SEOManager
 
         if ($data === null) {
             $data = [
-                'title' => $this->raw('title'),
-                'description' => $this->raw('description'),
+                'previewify:title' => $this->raw('title'),
+                'previewify:description' => $this->raw('description'),
             ];
         }
 

--- a/tests/Pest/PreviewifyTest.php
+++ b/tests/Pest/PreviewifyTest.php
@@ -18,16 +18,16 @@ test('previewify makes a request to the template not the alias', function () {
 
 test('previewify templates can be given data', function () {
     seo()->previewify('blog', 1);
-    expect(seo()->previewify('blog', ['title' => 'abc', 'excerpt' => 'def']))
+    expect(seo()->previewify('blog', ['previewify:title' => 'abc', 'previewify:excerpt' => 'def']))
         ->toContain('previewify.app/generate/templates/1')
-        ->toContain(base64_encode(json_encode(['title' => 'abc', 'excerpt' => 'def'])));
+        ->toContain(base64_encode(json_encode(['previewify:title' => 'abc', 'previewify:excerpt' => 'def'])));
 });
 
 test('the previewify method returns a link to a signed url', function () {
     seo()->previewify('blog', 1);
 
-    expect(seo()->previewify('blog', ['title' => 'abc']))
-        ->toContain('?signature=' . hash_hmac('sha256', base64_encode(json_encode(['title' => 'abc'])), config('services.previewify.key')));
+    expect(seo()->previewify('blog', ['previewify:title' => 'abc']))
+        ->toContain('?signature=' . hash_hmac('sha256', base64_encode(json_encode(['previewify:title' => 'abc'])), config('services.previewify.key')));
 });
 
 test("previewify templates use default data when they're not passed any data explicitly", function () {
@@ -37,7 +37,7 @@ test("previewify templates use default data when they're not passed any data exp
 
     expect(seo()->previewify('blog'))
         ->toContain('previewify.app/generate/templates/1')
-        ->toContain(base64_encode(json_encode(['title' => 'foo', 'description' => 'bar'])));
+        ->toContain(base64_encode(json_encode(['previewify:title' => 'foo', 'previewify:description' => 'bar'])));
 });
 
 test('previewify images are used as the cover images', function () {
@@ -55,7 +55,7 @@ test('the blade directive can be used with previewify', function () {
     seo()->title('foo')->description('bar');
 
     expect(blade("@seo('previewify', 'blog')"))->toBe(seo()->previewify('blog'));
-    expect(blade("@seo('previewify', 'blog', ['title' => 'abc'])"))->toBe(seo()->previewify('blog', ['title' => 'abc']));
+    expect(blade("@seo('previewify', 'blog', ['previewify:title' => 'abc'])"))->toBe(seo()->previewify('blog', ['previewify:title' => 'abc']));
 });
 
 test('previewify uses the raw title and description', function () {
@@ -66,12 +66,12 @@ test('previewify uses the raw title and description', function () {
 
     expect(seo()->previewify('blog'))
         ->toContain('previewify.app/generate/templates/1')
-        ->toContain(base64_encode(json_encode(['title' => 'foo', 'description' => 'bar'])));
+        ->toContain(base64_encode(json_encode(['previewify:title' => 'foo', 'previewify:description' => 'bar'])));
 });
 
 test('the @seo helper can be used for setting a previewify image', function () {
 	seo()->previewify('blog', 1);
-	blade("@seo(['previewify' => ['blog', ['title' => 'abc', 'excerpt' => 'def']]])");
+	blade("@seo(['previewify' => ['blog', ['previewify:title' => 'abc', 'previewify:excerpt' => 'def']]])");
 
 	expect(seo('image'))->toContain('previewify.app/generate/templates/1');
 });


### PR DESCRIPTION
I wasn't aware that previewify attributes always need a prefix. So I had to change the implementation to comply with that requirement.