### PR TITLE
Add previewify prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,9 @@ The `previewify()` method also returns a signed URL to the image, which lets you
 <img alt="@seo('title')" src="@seo('previewify', 'blog')">
 ```
 
+> **Note**
+> The `previewify:` prefix will be automatically prepended to all provided data keys.
+ 
 ## Examples
 
 ### Service Provider

--- a/src/SEOManager.php
+++ b/src/SEOManager.php
@@ -196,11 +196,11 @@ class SEOManager
                 'previewify:description' => $this->raw('description'),
             ];
         } else {
-            $data = array_combine(
-                array_map(fn ($key) => "previewify:{$key}", array_keys($data)),
-                $data,
-            );
-        }
+			$data = array_combine(
+				array_map(fn ($key) => str_starts_with($key, 'previewify:') ? $key : "previewify:{$key}", array_keys($data)),
+				$data,
+			);
+		}
 
         $query = base64_encode(json_encode($data, JSON_THROW_ON_ERROR));
 

--- a/src/SEOManager.php
+++ b/src/SEOManager.php
@@ -196,11 +196,11 @@ class SEOManager
                 'previewify:description' => $this->raw('description'),
             ];
         } else {
-			$data = array_combine(
-				array_map(fn ($key) => "previewify:{$key}", array_keys($data)),
-				$data,
-			);
-		}
+            $data = array_combine(
+                array_map(fn ($key) => "previewify:{$key}", array_keys($data)),
+                $data,
+            );
+        }
 
         $query = base64_encode(json_encode($data, JSON_THROW_ON_ERROR));
 

--- a/src/SEOManager.php
+++ b/src/SEOManager.php
@@ -192,10 +192,15 @@ class SEOManager
 
         if ($data === null) {
             $data = [
-                'title' => $this->raw('title'),
-                'description' => $this->raw('description'),
+                'previewify:title' => $this->raw('title'),
+                'previewify:description' => $this->raw('description'),
             ];
-        }
+        } else {
+			$data = array_combine(
+				array_map(fn ($key) => "previewify:{$key}", array_keys($data)),
+				$data,
+			);
+		}
 
         $query = base64_encode(json_encode($data, JSON_THROW_ON_ERROR));
 

--- a/src/SEOManager.php
+++ b/src/SEOManager.php
@@ -196,11 +196,11 @@ class SEOManager
                 'previewify:description' => $this->raw('description'),
             ];
         } else {
-			$data = array_combine(
-				array_map(fn ($key) => str_starts_with($key, 'previewify:') ? $key : "previewify:{$key}", array_keys($data)),
-				$data,
-			);
-		}
+            $data = array_combine(
+                array_map(fn ($key) => str_starts_with($key, 'previewify:') ? $key : "previewify:{$key}", array_keys($data)),
+                $data,
+            );
+        }
 
         $query = base64_encode(json_encode($data, JSON_THROW_ON_ERROR));
 

--- a/tests/Pest/PreviewifyTest.php
+++ b/tests/Pest/PreviewifyTest.php
@@ -18,7 +18,7 @@ test('previewify makes a request to the template not the alias', function () {
 
 test('previewify templates can be given data', function () {
     seo()->previewify('blog', 1);
-    expect(seo()->previewify('blog', ['title' => 'abc', 'excerpt' => 'def']))
+    expect(seo()->previewify('blog', ['title' => 'abc', 'previewify:excerpt' => 'def']))
         ->toContain('previewify.app/generate/templates/1')
         ->toContain(base64_encode(json_encode(['previewify:title' => 'abc', 'previewify:excerpt' => 'def'])));
 });

--- a/tests/Pest/PreviewifyTest.php
+++ b/tests/Pest/PreviewifyTest.php
@@ -20,14 +20,14 @@ test('previewify templates can be given data', function () {
     seo()->previewify('blog', 1);
     expect(seo()->previewify('blog', ['title' => 'abc', 'excerpt' => 'def']))
         ->toContain('previewify.app/generate/templates/1')
-        ->toContain(base64_encode(json_encode(['title' => 'abc', 'excerpt' => 'def'])));
+        ->toContain(base64_encode(json_encode(['previewify:title' => 'abc', 'previewify:excerpt' => 'def'])));
 });
 
 test('the previewify method returns a link to a signed url', function () {
     seo()->previewify('blog', 1);
 
     expect(seo()->previewify('blog', ['title' => 'abc']))
-        ->toContain('?signature=' . hash_hmac('sha256', base64_encode(json_encode(['title' => 'abc'])), config('services.previewify.key')));
+        ->toContain('?signature=' . hash_hmac('sha256', base64_encode(json_encode(['previewify:title' => 'abc'])), config('services.previewify.key')));
 });
 
 test("previewify templates use default data when they're not passed any data explicitly", function () {
@@ -37,7 +37,7 @@ test("previewify templates use default data when they're not passed any data exp
 
     expect(seo()->previewify('blog'))
         ->toContain('previewify.app/generate/templates/1')
-        ->toContain(base64_encode(json_encode(['title' => 'foo', 'description' => 'bar'])));
+        ->toContain(base64_encode(json_encode(['previewify:title' => 'foo', 'previewify:description' => 'bar'])));
 });
 
 test('previewify images are used as the cover images', function () {
@@ -66,7 +66,7 @@ test('previewify uses the raw title and description', function () {
 
     expect(seo()->previewify('blog'))
         ->toContain('previewify.app/generate/templates/1')
-        ->toContain(base64_encode(json_encode(['title' => 'foo', 'description' => 'bar'])));
+        ->toContain(base64_encode(json_encode(['previewify:title' => 'foo', 'previewify:description' => 'bar'])));
 });
 
 test('the @seo helper can be used for setting a previewify image', function () {


### PR DESCRIPTION
As discussed in #23 Previewify data keys need a prefix to work correctly. I changed the implementation to your recommendation of automatically prefixing the keys.