### PR TITLE
Adds support for og:locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ url(string $url)
 title(string $title)
 description(string $description)
 image(string $url)
+locale(string $locale)
 
 twitterCreator(string $username)
 twitterSite(string $username)
@@ -157,6 +158,16 @@ If you wish to change the URL, call `seo()->url()`:
 ```php
 seo()->url(route('products.show', $this->product));
 ```
+
+### Locale
+
+To set the `og:locale` property:
+
+```php
+seo()->locale('de_DE');
+```
+
+Expected format is `language_TERRITORY`.
 
 ### Modifiers
 

--- a/assets/views/components/meta.blade.php
+++ b/assets/views/components/meta.blade.php
@@ -20,6 +20,8 @@
 
 @if(seo('site')) <meta property="og:site_name" content="@seo('site')"> @endif
 
+@if(seo('locale')) <meta property="og:locale" content="@seo('locale')" /> @endif
+
 @if(seo('image')) <meta property="og:image" content="@seo('image')" /> @endif
 
 @if(seo('url'))

--- a/src/SEOManager.php
+++ b/src/SEOManager.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Str;
  * @method $this site(string $site = null, ...$args) Set the site name.
  * @method $this image(string $url = null, ...$args) Set the cover image.
  * @method $this type(string $type = null, ...$args) Set the page type.
+ * @method $this locale(string $locale = null, ...$args) Set the page locale.
  * @method $this twitter(enabled $bool = true, ...$args) Enable the Twitter extension.
  * @method $this twitterCreator(string $username = null, ...$args) Set the Twitter author.
  * @method $this twitterSite(string $username = null, ...$args) Set the Twitter author.
@@ -56,7 +57,7 @@ class SEOManager
     protected function getKeys(): array
     {
         return collect([
-                'site', 'title', 'image', 'description', 'url', 'type',
+                'site', 'title', 'image', 'description', 'url', 'type', 'locale',
                 'twitter.creator', 'twitter.site', 'twitter.title', 'twitter.image', 'twitter.description',
             ])
             ->merge(array_keys($this->defaults))

--- a/tests/Pest/ManagerTest.php
+++ b/tests/Pest/ManagerTest.php
@@ -146,3 +146,14 @@ test('type can be overridden using the type method', function () {
         ->toContain('<meta property="og:type" content="foo" />') // overridden
         ->not()->toContain('website');
 });
+
+test('og:locale is not included by default', function () {
+    expect(meta())
+        ->not()->toContain('og:locale');
+});
+
+test('og:locale can be added to the template', function () {
+    seo()->locale('de_DE');
+
+    expect(meta())->toContain('<meta property="og:locale" content="de_DE" />');
+});


### PR DESCRIPTION
This pull request adds the possibility to set and/or overwrite the Open Graph content language property:

```php
seo()->locale('de_DE');
```

Output:
```html
<meta property="og:locale" content="de_DE" /> 
```
