### PR TITLE
Update SEOServiceProvider.php

### DIFF
--- a/src/SEOServiceProvider.php
+++ b/src/SEOServiceProvider.php
@@ -12,7 +12,7 @@ class SEOServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        $this->app->singleton('seo', SEOManager::class);
+        $this->app->scoped('seo', SEOManager::class);
     }
 
     public function boot(): void


### PR DESCRIPTION
Using this package with [Laravel Octane](https://laravel.com/docs/11.x/octane) causes any values that aren't explicitly set on the current page to be filled with data from other pages that were populated on prior requests.

I believe the fix is to register the SEOManager as a scoped singleton in the SEOServiceProvider. Here's the relevant section of the docs:

> [Binding Scoped Singletons](https://laravel.com/docs/11.x/container#binding-scoped)
The scoped method binds a class or interface into the container that should only be resolved one time within a given Laravel request / job lifecycle. While this method is similar to the singleton method, instances registered using the scoped method will be flushed whenever the Laravel application starts a new "lifecycle", such as when a [Laravel Octane](https://laravel.com/docs/11.x/octane) worker processes a new request or when a Laravel [queue worker](https://laravel.com/docs/11.x/queues) processes a new job

closes #35