### PR TITLE
Add optional origin to withUrl

### DIFF
--- a/src/SEOManager.php
+++ b/src/SEOManager.php
@@ -224,9 +224,13 @@ class SEOManager
     }
 
     /** Append canonical URL tags to the document head. */
-    public function withUrl(): static
+    public function withUrl(?string $origin = null): static
     {
-        $this->url(request()->url());
+        if($origin){
+            $this->url(trim($origin, '/') . '/' . trim(request()->path(), '/'));
+        }else{
+            $this->url(request()->url());
+        }
 
         return $this;
     }

--- a/tests/Pest/ManagerTest.php
+++ b/tests/Pest/ManagerTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use ArchTech\SEO\SEOManager;
+use Illuminate\Http\Request;
+use Mockery\MockInterface;
 
 test('set returns the set value', function () {
     expect(seo()->set('foo', 'bar'))->toBe('bar');
@@ -116,6 +118,16 @@ test('canonical url can be read from request', function () {
     expect(meta())
         ->toContain('<meta property="og:url" content="http://localhost" />')
         ->toContain('<link rel="canonical" href="http://localhost" />');
+});
+
+test('canonical url accepts origin', function () {
+    $this->get('/testing/5');
+
+    seo()->withUrl('https://foo.com');
+
+    expect(meta())
+        ->toContain('<meta property="og:url" content="https://foo.com/testing/5" />')
+        ->toContain('<link rel="canonical" href="https://foo.com/testing/5" />');
 });
 
 test('canonical url can be changed', function () {


### PR DESCRIPTION
This pull request adds an optional `$origin` parameter to the `withUrl()` method allowing users to set a fixed origin such as `https://foo.com`. This useful to prevent duplicate content issues with publicly accessible test environments or underlying serverless functions that alias to your domain.