### PR TITLE
Update meta tags to be HTML5 compliant by removing self-closing slashes

### DIFF
--- a/resources/views/components/meta.blade.php
+++ b/resources/views/components/meta.blade.php
@@ -1,42 +1,48 @@
-@if(seo('title'))
+@if (seo('title'))
     <title>@seo('title')</title>
 
-    @unless(seo()->hasTag('og:title'))
+    @unless (seo()->hasTag('og:title'))
         {{-- If an og:title tag is provided directly, it's included in the @foreach below --}}
-        <meta property="og:title" content="@seo('title')" />
+        <meta property="og:title" content="@seo('title')">
     @endunless
 @endif
 
-@if(seo('description'))
-    <meta property="og:description" content="@seo('description')" />
-    <meta name="description" content="@seo('description')" />
+@if (seo('description'))
+    <meta property="og:description" content="@seo('description')">
+    <meta name="description" content="@seo('description')">
 @endif
 
-@if(seo('keywords'))
-    <meta name="keywords" content="@seo('keywords')" />
+@if (seo('keywords'))
+    <meta name="keywords" content="@seo('keywords')">
 @endif
 
-@if(seo('type'))
-    <meta property="og:type" content="@seo('type')" />
+@if (seo('type'))
+    <meta property="og:type" content="@seo('type')">
 @else
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content="website">
 @endif
 
-@if(seo('site')) <meta property="og:site_name" content="@seo('site')" /> @endif
-
-@if(seo('locale')) <meta property="og:locale" content="@seo('locale')" /> @endif
-
-@if(seo('image')) <meta property="og:image" content="@seo('image')" /> @endif
-
-@if(seo('url'))
-    <meta property="og:url" content="@seo('url')" />
-    <link rel="canonical" href="@seo('url')" />
+@if (seo('site'))
+    <meta property="og:site_name" content="@seo('site')">
 @endif
 
-@foreach(seo()->tags() as $tag)
+@if (seo('locale'))
+    <meta property="og:locale" content="@seo('locale')">
+@endif
+
+@if (seo('image'))
+    <meta property="og:image" content="@seo('image')">
+@endif
+
+@if (seo('url'))
+    <meta property="og:url" content="@seo('url')">
+    <link rel="canonical" href="@seo('url')">
+@endif
+
+@foreach (seo()->tags() as $tag)
     {!! $tag !!}
 @endforeach
 
-@foreach(seo()->extensions() as $extension)
+@foreach (seo()->extensions() as $extension)
     <x-dynamic-component :component="$extension" />
 @endforeach

--- a/resources/views/components/meta.blade.php
+++ b/resources/views/components/meta.blade.php
@@ -1,48 +1,42 @@
-@if (seo('title'))
+@if(seo('title'))
     <title>@seo('title')</title>
 
-    @unless (seo()->hasTag('og:title'))
+    @unless(seo()->hasTag('og:title'))
         {{-- If an og:title tag is provided directly, it's included in the @foreach below --}}
         <meta property="og:title" content="@seo('title')">
     @endunless
 @endif
 
-@if (seo('description'))
+@if(seo('description'))
     <meta property="og:description" content="@seo('description')">
     <meta name="description" content="@seo('description')">
 @endif
 
-@if (seo('keywords'))
+@if(seo('keywords'))
     <meta name="keywords" content="@seo('keywords')">
 @endif
 
-@if (seo('type'))
+@if(seo('type'))
     <meta property="og:type" content="@seo('type')">
 @else
     <meta property="og:type" content="website">
 @endif
 
-@if (seo('site'))
-    <meta property="og:site_name" content="@seo('site')">
-@endif
+@if(seo('site')) <meta property="og:site_name" content="@seo('site')"> @endif
 
-@if (seo('locale'))
-    <meta property="og:locale" content="@seo('locale')">
-@endif
+@if(seo('locale')) <meta property="og:locale" content="@seo('locale')"> @endif
 
-@if (seo('image'))
-    <meta property="og:image" content="@seo('image')">
-@endif
+@if(seo('image')) <meta property="og:image" content="@seo('image')"> @endif
 
-@if (seo('url'))
+@if(seo('url'))
     <meta property="og:url" content="@seo('url')">
     <link rel="canonical" href="@seo('url')">
 @endif
 
-@foreach (seo()->tags() as $tag)
+@foreach(seo()->tags() as $tag)
     {!! $tag !!}
 @endforeach
 
-@foreach (seo()->extensions() as $extension)
+@foreach(seo()->extensions() as $extension)
     <x-dynamic-component :component="$extension" />
 @endforeach


### PR DESCRIPTION
This pull request removes the unnecessary self-closing slashes (/>) in the meta tags to ensure HTML5 compliance. This resolves issues related to invalid markup. Fixes #32 