### PR TITLE
Intervention Image v3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
         coverage: none
     - name: Install composer dependencies
       run: |
-        composer require "laravel/framework:^${{matrix.laravel}}.0"
-        composer require "intervention/image:^${{matrix.intervention}}.0"
+        composer require --dev "laravel/framework:^${{matrix.laravel}}.0"
+        composer require --dev "intervention/image:^${{matrix.intervention}}.0"
     - name: Run tests
       run: vendor/bin/pest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,12 @@ on:
 
 jobs:
   pest:
-    name: Tests (Pest) L${{ matrix.laravel }}
+    name: Tests (Pest) L${{ matrix.laravel }} I${{ matrix.intervention }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         laravel: [10, 11, 12]
+        intervention: [2, 3]
 
     steps:
     - uses: actions/checkout@v2
@@ -22,7 +23,9 @@ jobs:
         tools: composer:v2
         coverage: none
     - name: Install composer dependencies
-      run: composer require "laravel/framework:^${{matrix.laravel}}.0"
+      run: |
+        composer require "laravel/framework:^${{matrix.laravel}}.0"
+        composer require "intervention/image:^${{matrix.intervention}}.0"
     - name: Run tests
       run: vendor/bin/pest
 

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
     },
     "require-dev": {
         "orchestra/testbench": ">=8.0",
-        "nunomaduro/larastan": ">=2.4",
+        "larastan/larastan": ">=2.4",
         "pestphp/pest": ">=2.0",
         "pestphp/pest-plugin-laravel": ">=2.0",
-        "intervention/image": "^2.7"
+        "intervention/image": "^2.0|^3.0"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "larastan/larastan": ">=2.4",
         "pestphp/pest": ">=2.0",
         "pestphp/pest-plugin-laravel": ">=2.0",
-        "intervention/image": "^2.0|^3.0"
+        "intervention/image": "^2.7|^3.0"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "larastan/larastan": ">=2.4",
         "pestphp/pest": ">=2.0",
         "pestphp/pest-plugin-laravel": ">=2.0",
-        "intervention/image": "^2.7|^3.0"
+        "intervention/image": "^3.0"
     },
     "extra": {
         "laravel": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - ./vendor/nunomaduro/larastan/extension.neon
+    - ./vendor/larastan/larastan/extension.neon
 
 parameters:
     paths:

--- a/src/Commands/GenerateFaviconsCommand.php
+++ b/src/Commands/GenerateFaviconsCommand.php
@@ -38,9 +38,9 @@ class GenerateFaviconsCommand extends Command
         }
 
         // Check Intervention Image version
-        $isV3 = interface_exists('\Intervention\Image\Interfaces\DriverInterface');
+        $interventionV3 = interface_exists('\Intervention\Image\Interfaces\DriverInterface');
 
-        if ($isV3) {
+        if ($interventionV3) {
             // v3.x implementation
             $manager = new ImageManager(
                 new \Intervention\Image\Drivers\Imagick\Driver()

--- a/src/Commands/GenerateFaviconsCommand.php
+++ b/src/Commands/GenerateFaviconsCommand.php
@@ -60,14 +60,14 @@ class GenerateFaviconsCommand extends Command
             $manager = new ImageManager(['driver' => 'imagick']); // @phpstan-ignore argument.type
 
             $this->comment('Generating ico...');
-            $manager // @phpstan-ignore method.notFound
-                ->make($path)
+            $manager
+                ->make($path) // @phpstan-ignore method.notFound
                 ->resize(32, 32)
                 ->save(public_path('favicon.ico'));
 
             $this->comment('Generating png...');
-            $manager // @phpstan-ignore method.notFound
-                ->make($path)
+            $manager
+                ->make($path) // @phpstan-ignore method.notFound
                 ->resize(32, 32)
                 ->save(public_path('favicon.png'));
         }

--- a/src/Commands/GenerateFaviconsCommand.php
+++ b/src/Commands/GenerateFaviconsCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ArchTech\SEO\Commands;
 
 use Illuminate\Console\Command;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
 use Intervention\Image\ImageManager;
 
 class GenerateFaviconsCommand extends Command
@@ -38,7 +39,7 @@ class GenerateFaviconsCommand extends Command
         }
 
         // GD driver doesn't support .ico, that's why we use ImageMagick.
-        $manager = new ImageManager(['driver' => 'imagick']);
+        $manager = new ImageManager(ImagickDriver::class);
 
         $this->comment('Generating ico...');
 

--- a/src/Commands/GenerateFaviconsCommand.php
+++ b/src/Commands/GenerateFaviconsCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ArchTech\SEO\Commands;
 
 use Illuminate\Console\Command;
-use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
 use Intervention\Image\ImageManager;
 
 class GenerateFaviconsCommand extends Command
@@ -38,22 +37,40 @@ class GenerateFaviconsCommand extends Command
             return self::FAILURE;
         }
 
-        // GD driver doesn't support .ico, that's why we use ImageMagick.
-        $manager = new ImageManager(ImagickDriver::class);
+        // Check Intervention Image version
+        $isV3 = interface_exists('\Intervention\Image\Interfaces\DriverInterface');
 
-        $this->comment('Generating ico...');
+        if ($isV3) {
+            // v3.x implementation
+            $manager = new ImageManager(
+                new \Intervention\Image\Drivers\Imagick\Driver()
+            );
 
-        $manager
-            ->make($path)
-            ->resize(32, 32)
-            ->save(public_path('favicon.ico'));
+            $this->comment('Generating ico...');
+            $image = $manager->read($path);
+            $image->resize(32, 32);
+            $image->save(public_path('favicon.ico'));
 
-        $this->comment('Generating png...');
+            $this->comment('Generating png...');
+            $image = $manager->read($path);
+            $image->resize(32, 32);
+            $image->save(public_path('favicon.png'));
+        } else {
+            // v2.x implementation
+            $manager = new ImageManager(['driver' => 'imagick']); // @phpstan-ignore argument.type
 
-        $manager
-            ->make($path)
-            ->resize(32, 32)
-            ->save(public_path('favicon.png'));
+            $this->comment('Generating ico...');
+            $manager // @phpstan-ignore method.notFound
+                ->make($path)
+                ->resize(32, 32)
+                ->save(public_path('favicon.ico'));
+
+            $this->comment('Generating png...');
+            $manager // @phpstan-ignore method.notFound
+                ->make($path)
+                ->resize(32, 32)
+                ->save(public_path('favicon.png'));
+        }
 
         $this->info('All favicons have been generated!');
 


### PR DESCRIPTION
This PR addresses a TypeError that occurs when running the `seo:generate-favicons` command with Intervention Image v3. The current implementation is passing an array configuration to the ImageManager constructor, which is no longer compatible with the v3 API that requires a driver instance or class name as the first argument.

### Changes made:
- Import the Intervention\Image\Drivers\Imagick\Driver class
- Update the ImageManager instantiation to use the new constructor pattern with ImagickDriver::class instead of an array configuration

### Issue fixed:
This resolves the following error that occurs when trying to generate favicons:
```
TypeError: Intervention\Image\ImageManager::__construct(): Argument #1 ($driver) must be of type Intervention\Image\Interfaces\DriverInterface|string, array given
```

### Testing:
The command was tested with Intervention Image v3 and successfully generates all favicon files as expected.